### PR TITLE
Assign default uuid to ccpaUUID

### DIFF
--- a/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
@@ -54,7 +54,7 @@ public typealias TargetingParams = [String:String]
     public var userConsent: UserConsent
 
     /// The UUID assigned to a user, available after calling `loadMessage`
-    public var consentUUID: ConsentUUID?
+    public var consentUUID: ConsentUUID
     
     /// Instructs the SDK to clean consent data if an error occurs. It's `true` by default.
     public var shouldCleanConsentOnError = true
@@ -113,7 +113,7 @@ public typealias TargetingParams = [String:String]
         }
         self.userConsent = (UserDefaults.standard.object(forKey: CCPAConsentViewController.CCPA_USER_CONSENTS) as? UserConsent) ??
             UserConsent(status: .RejectedNone, rejectedVendors: [], rejectedCategories: [])
-        self.consentUUID = UserDefaults.standard.string(forKey: CCPAConsentViewController.CONSENT_UUID_KEY)
+        self.consentUUID = UserDefaults.standard.string(forKey: CCPAConsentViewController.CONSENT_UUID_KEY) ?? UUID().uuidString
         
         self.sourcePoint = SourcePointClient(
             accountId: accountId,

--- a/CCPAConsentViewController/Classes/SourcePointClient.swift
+++ b/CCPAConsentViewController/Classes/SourcePointClient.swift
@@ -125,7 +125,7 @@ class SourcePointClient {
         }
     }
 
-    func getMessageUrl(_ consentUUID: ConsentUUID?, propertyName: PropertyName) -> URL? {
+    func getMessageUrl(_ consentUUID: ConsentUUID, propertyName: PropertyName) -> URL? {
         var components = URLComponents(url: SourcePointClient.WRAPPER_API, resolvingAgainstBaseURL: true)
         components?.path = "/ccpa/message-url"
         components?.queryItems = [
@@ -142,7 +142,7 @@ class SourcePointClient {
         return components?.url
     }
 
-    func getMessage(consentUUID: ConsentUUID?, onSuccess: @escaping (MessageResponse) -> Void) {
+    func getMessage(consentUUID: ConsentUUID, onSuccess: @escaping (MessageResponse) -> Void) {
         let url = getMessageUrl(consentUUID, propertyName: propertyName)
         client.get(url: url) { [weak self] data in
             do {


### PR DESCRIPTION
This was causing https://sourcepoint.atlassian.net/browse/SP-3039

TL;DR;
In the second app launch, the ccpaUUID was `nil` but Meta wasn't and the wrapper api returns an error in that case.