### PR TITLE
[SP-3462] add authId to SourcePointClient

### DIFF
--- a/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
@@ -63,7 +63,7 @@ public typealias TargetingParams = [String:String]
     }
     
     private static func getStoredConsentUUID() -> ConsentUUID {
-        return UserDefaults.standard.string(forKey: CONSENT_UUID_KEY) ?? UUID().uuidString
+        return UserDefaults.standard.string(forKey: CONSENT_UUID_KEY) ?? ""
     }
     
     /// Contains the `ConsentStatus`, an array of rejected vendor ids and and array of rejected purposes

--- a/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
@@ -167,6 +167,7 @@ public typealias TargetingParams = [String:String]
             }
             sourcePoint.getMessage(consentUUID: consentUUID, authId: authId) { [weak self] message in
                 self?.loading = .Ready
+                self?.consentUUID = message.uuid
                 if let url = message.url {
                     self?.loadMessage(fromUrl: url)
                 } else {

--- a/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
@@ -178,7 +178,8 @@ public typealias TargetingParams = [String:String]
     }
     
     private func didAuthIdChange(newAuthId: String?) -> Bool {
-        return newAuthId != UserDefaults.standard.string(forKey: CCPAConsentViewController.CCPA_AUTH_ID_KEY)
+        let storedAuthId = UserDefaults.standard.string(forKey: CCPAConsentViewController.CCPA_AUTH_ID_KEY)
+        return newAuthId != nil && storedAuthId != nil && storedAuthId != newAuthId
     }
 
     /// Will first check if there's a message to show according to the scenario setup in our dashboard.

--- a/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
@@ -152,18 +152,30 @@ public typealias TargetingParams = [String:String]
         messageViewController?.loadMessage(fromUrl: url)
     }
     
-    public func loadMessage() {
+    /// Will first check if there's a message to show according to the scenario, for the `authId` provided.
+    /// If there is, we'll load the message in a WebView and call `ConsentDelegate.onConsentUIWillShow`
+    /// Otherwise, we short circuit to `ConsentDelegate.onConsentReady`
+    ///
+    /// - Parameter authId: any arbitrary token that uniquely identifies an user in your system.
+    public func loadMessage(forAuthId authId: String?) {
         if loading == .Ready {
             loading = .Loading
-            sourcePoint.getMessage(consentUUID: consentUUID) { [weak self] message in
+            sourcePoint.getMessage(consentUUID: consentUUID, authId: authId) { [weak self] message in
+                self?.loading = .Ready
                 if let url = message.url {
                     self?.loadMessage(fromUrl: url)
                 } else {
-                    self?.loading = .Ready
                     self?.onConsentReady(consentUUID: message.uuid, userConsent: message.userConsent)
                 }
             }
         }
+    }
+
+    /// Will first check if there's a message to show according to the scenario setup in our dashboard.
+    /// If there is, we'll load the message in a WebView and call `ConsentDelegate.onConsentUIWillShow`
+    /// Otherwise, we short circuit to `ConsentDelegate.onConsentReady`
+    public func loadMessage() {
+        loadMessage(forAuthId: nil)
     }
 
     public func loadPrivacyManager() {

--- a/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
@@ -13,6 +13,7 @@ public typealias TargetingParams = [String:String]
 @objcMembers open class CCPAConsentViewController: UIViewController {
     static public let CCPA_USER_CONSENTS: String = "sp_ccpa_user_consents"
     static public let CONSENT_UUID_KEY: String = "sp_ccpa_consentUUID"
+    static let CCPA_AUTH_ID_KEY = "sp_ccpa_authId"
     static public let META_KEY: String = "sp_ccpa_meta"
 
     private let accountId, propertyId: Int
@@ -160,6 +161,10 @@ public typealias TargetingParams = [String:String]
     public func loadMessage(forAuthId authId: String?) {
         if loading == .Ready {
             loading = .Loading
+            if didAuthIdChange(newAuthId: (authId)) {
+                resetConsentData()
+                UserDefaults.standard.setValue(authId, forKey: CCPAConsentViewController.CCPA_AUTH_ID_KEY)
+            }
             sourcePoint.getMessage(consentUUID: consentUUID, authId: authId) { [weak self] message in
                 self?.loading = .Ready
                 if let url = message.url {
@@ -169,6 +174,10 @@ public typealias TargetingParams = [String:String]
                 }
             }
         }
+    }
+    
+    private func didAuthIdChange(newAuthId: String?) -> Bool {
+        return newAuthId != UserDefaults.standard.string(forKey: CCPAConsentViewController.CCPA_AUTH_ID_KEY)
     }
 
     /// Will first check if there's a message to show according to the scenario setup in our dashboard.
@@ -186,9 +195,15 @@ public typealias TargetingParams = [String:String]
             messageViewController?.loadPrivacyManager()
         }
     }
+    
+    private func resetConsentData() {
+        self.consentUUID = ""
+        clearAllConsentData()
+    }
 
     /// Remove all consent related data from the UserDefaults
     public func clearAllConsentData() {
+        UserDefaults.standard.removeObject(forKey: CCPAConsentViewController.CCPA_AUTH_ID_KEY)
         UserDefaults.standard.removeObject(forKey: CCPAConsentViewController.CCPA_USER_CONSENTS)
         UserDefaults.standard.removeObject(forKey: CCPAConsentViewController.CONSENT_UUID_KEY)
         UserDefaults.standard.removeObject(forKey: CCPAConsentViewController.META_KEY)

--- a/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
@@ -161,9 +161,9 @@ public typealias TargetingParams = [String:String]
     public func loadMessage(forAuthId authId: String?) {
         if loading == .Ready {
             loading = .Loading
+            UserDefaults.standard.setValue(authId, forKey: CCPAConsentViewController.CCPA_AUTH_ID_KEY)
             if didAuthIdChange(newAuthId: (authId)) {
                 resetConsentData()
-                UserDefaults.standard.setValue(authId, forKey: CCPAConsentViewController.CCPA_AUTH_ID_KEY)
             }
             sourcePoint.getMessage(consentUUID: consentUUID, authId: authId) { [weak self] message in
                 self?.loading = .Ready

--- a/CCPAConsentViewController/Classes/SourcePointClient.swift
+++ b/CCPAConsentViewController/Classes/SourcePointClient.swift
@@ -125,11 +125,12 @@ class SourcePointClient {
         }
     }
 
-    func getMessageUrl(_ consentUUID: ConsentUUID, propertyName: PropertyName) -> URL? {
+    func getMessageUrl(_ consentUUID: ConsentUUID, propertyName: PropertyName, authId: String?) -> URL? {
         var components = URLComponents(url: SourcePointClient.WRAPPER_API, resolvingAgainstBaseURL: true)
         components?.path = "/ccpa/message-url"
         components?.queryItems = [
             URLQueryItem(name: "uuid", value: consentUUID),
+            URLQueryItem(name: "authId", value: authId),
             URLQueryItem(name: "propertyId", value: String(propertyId)),
             URLQueryItem(name: "accountId", value: String(accountId)),
             URLQueryItem(name: "requestUUID", value: requestUUID.uuidString),
@@ -142,8 +143,8 @@ class SourcePointClient {
         return components?.url
     }
 
-    func getMessage(consentUUID: ConsentUUID, onSuccess: @escaping (MessageResponse) -> Void) {
-        let url = getMessageUrl(consentUUID, propertyName: propertyName)
+    func getMessage(consentUUID: ConsentUUID, authId: String?, onSuccess: @escaping (MessageResponse) -> Void) {
+        let url = getMessageUrl(consentUUID, propertyName: propertyName, authId: authId)
         client.get(url: url) { [weak self] data in
             do {
                 let messageResponse = try (self?.json.decode(MessageResponse.self, from: data))!

--- a/CCPAConsentViewController/Classes/SourcePointClient.swift
+++ b/CCPAConsentViewController/Classes/SourcePointClient.swift
@@ -163,7 +163,7 @@ class SourcePointClient {
         )
     }
     
-    func postAction(action: Action, consentUUID: ConsentUUID?, consents: PMConsents?, onSuccess: @escaping (ActionResponse) -> Void) {
+    func postAction(action: Action, consentUUID: ConsentUUID, consents: PMConsents?, onSuccess: @escaping (ActionResponse) -> Void) {
         let url = postActionUrl(action.rawValue)
         let meta = UserDefaults.standard.string(forKey: CCPAConsentViewController.META_KEY) ?? "{}"
         let ccpaConsents = CPPAPMConsents(rejectedVendors: consents?.vendors.rejected ?? [], rejectedCategories: consents?.categories.rejected ?? [])

--- a/CCPAConsentViewController/Classes/SourcePointClient.swift
+++ b/CCPAConsentViewController/Classes/SourcePointClient.swift
@@ -20,6 +20,31 @@ protocol HttpClient {
 class SimpleClient: HttpClient {
     var defaultOnError: OnError?
     let connectivityManager: Connectivity
+    let printCalls = false
+
+    func logRequest(_ request: URLRequest) {
+        if printCalls {
+            if let method = request.httpMethod, let url = request.url {
+                print("\(method) \(url)")
+            }
+            if let body = request.httpBody, let bodyString = String(data: body, encoding: .utf8) {
+                print("REQUEST: \(bodyString)")
+            }
+            print("\n")
+        }
+    }
+
+    func logResponse(_ request: URLRequest, response: Data) {
+        if printCalls {
+            if let method = request.httpMethod, let url = request.url {
+                print("\(method) \(url)")
+            }
+            if let responseString =  String(data: response, encoding: .utf8) {
+                print("RESPONSE: \(responseString)")
+            }
+            print("\n")
+        }
+    }
     
     init(connectivityManager: Connectivity) {
         self.connectivityManager = connectivityManager
@@ -31,12 +56,14 @@ class SimpleClient: HttpClient {
     
     func request(_ urlRequest: URLRequest, _ onSuccess: @escaping OnSuccess) {
         if(connectivityManager.isConnectedToNetwork()) {
+            logRequest(urlRequest)
             URLSession.shared.dataTask(with: urlRequest) { data, response, error in
                 DispatchQueue.main.async { [weak self] in
                     guard let data = data else {
                         self?.defaultOnError?(GeneralRequestError(urlRequest.url, response, error))
                         return
                     }
+                    self?.logResponse(urlRequest, response: data)
                     onSuccess(data)
                 }
             }.resume()

--- a/CCPAConsentViewController/Classes/SourcePointRequestsResponses.swift
+++ b/CCPAConsentViewController/Classes/SourcePointRequestsResponses.swift
@@ -36,7 +36,7 @@ struct ActionRequest: WrapperApiRequest {
 
     let propertyId, accountId: Int
     let privacyManagerId: String
-    let uuid: ConsentUUID?
+    let uuid: ConsentUUID
     let requestUUID: UUID
     let consents: CPPAPMConsents
     let meta: Meta

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ import UIKit
 import CCPAConsentViewController
 
 class ViewController: UIViewController, ConsentDelegate {
-    let logger = Logger()
-
     lazy var consentViewController: CCPAConsentViewController = { return CCPAConsentViewController(
       accountId: 22,
       propertyId: 6099, 
@@ -59,7 +57,7 @@ class ViewController: UIViewController, ConsentDelegate {
     }
 
     func onError(error: CCPAConsentViewControllerError?) {
-        logger.log("Error: %{public}@", [error?.description ?? "Something Went Wrong"])
+        print("Error: \(error?.description ?? "Something Went Wrong")")
     }
 
     @IBAction func onPrivacySettingsTap(_ sender: Any) {
@@ -126,4 +124,22 @@ CCPAConsentViewController *cvc;
 }
 
 @end
+```
+
+### Authenticated Consent
+
+#### How does it work?
+You need to give us a `authId`, that can be anything, user name, email, uuid, as long as you can uniquely identifies an user in your user base.
+
+We'll check our database for a consent profile associated with that `authId`. If we find one, we'll bring it to the user's device and not show a consent message again (technically this will depend on the scenario setup in our dashboard). If we haven't found any consent profile for that `authId` we'll create one and associate with the current user. 
+
+#### How to use it?
+
+The workflow to use authenticated consent is exactly the same as the one above but instead of calling:
+```swift
+consentViewController.loadMessage()
+```
+you should use:
+```swift
+consentViewController.loadMessage(forAuthId: String?)
 ```


### PR DESCRIPTION
This PR adds authenticated consent to the CCPA SDK and fixes a few issues along the way, namely:

* stores `consentUUID` on get message response b8d6b7d
* stop generating our own `ConsentUUID` 593f568
* stores `authId` on `loadMessage` instead of only when the auth Id changed dc8d28d