### PR TITLE
[SP-4786] Update onError method declaration

### DIFF
--- a/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewController.swift
@@ -262,7 +262,7 @@ extension CCPAConsentViewController: ConsentDelegate {
         if shouldCleanConsentOnError {
             clearAllConsentData()
         }
-        consentDelegate?.onError?(error: error)
+        consentDelegate?.onError?(ccpaError: error)
     }
 
     public func onAction(_ action: Action, consents: PMConsents?) {

--- a/CCPAConsentViewController/Classes/ConsentDelegate.swift
+++ b/CCPAConsentViewController/Classes/ConsentDelegate.swift
@@ -44,5 +44,5 @@ import Foundation
     @objc optional func onConsentReady(consentUUID: ConsentUUID, userConsent: UserConsent)
 
     /// the `onError` function can be called at any moment during the SDKs lifecycle
-    @objc optional func onError(error: CCPAConsentViewControllerError?)
+    @objc optional func onError(ccpaError: CCPAConsentViewControllerError?)
 }

--- a/CCPAConsentViewController/Classes/MessageWebViewController.swift
+++ b/CCPAConsentViewController/Classes/MessageWebViewController.swift
@@ -22,7 +22,7 @@ class MessageWebViewController: MessageViewController, WKUIDelegate, WKNavigatio
         guard let scriptSource = try? String(
             contentsOfFile: Bundle(for: CCPAConsentViewController.self).path(forResource: MessageWebViewController.MESSAGE_HANDLER_NAME, ofType: "js")!)
             else {
-                consentDelegate?.onError?(error: UnableToLoadJSReceiver())
+                consentDelegate?.onError?(ccpaError: UnableToLoadJSReceiver())
                 return nil
         }
         let script = WKUserScript(source: scriptSource, injectionTime: .atDocumentStart, forMainFrameOnly: true)
@@ -104,7 +104,7 @@ class MessageWebViewController: MessageViewController, WKUIDelegate, WKNavigatio
     }
 
     func onError(error: CCPAConsentViewControllerError?) {
-        consentDelegate?.onError?(error: error)
+        consentDelegate?.onError?(ccpaError: error)
         closeConsentUIIfOpen()
     }
 

--- a/Example/CCPAConsentViewController/ViewController.swift
+++ b/Example/CCPAConsentViewController/ViewController.swift
@@ -52,8 +52,8 @@ extension ViewController: ConsentDelegate {
         print("US Privacy String:", UserDefaults.standard.string(forKey: CCPAConsentViewController.IAB_PRIVACY_STRING_KEY) ?? "")
     }
 
-    func onError(error: CCPAConsentViewControllerError?) {
-        print("Error:", error.debugDescription)
+    func onError(ccpaError: CCPAConsentViewControllerError?) {
+        print("Error:", ccpaError.debugDescription)
     }
 }
 

--- a/Example/CCPAConsentViewController_ExampleTests/CCPAConsentViewControllerSpec.swift
+++ b/Example/CCPAConsentViewController_ExampleTests/CCPAConsentViewControllerSpec.swift
@@ -35,7 +35,7 @@ public class MockConsentDelegate: ConsentDelegate {
         isConsentUIDidDisappearCalled = true
     }
 
-    public func onError(error: CCPAConsentViewControllerError?) {
+    public func onError(ccpaError: CCPAConsentViewControllerError?) {
         isOnErrorCalled = true
     }
 

--- a/Example/SourcePointMetaApp/Controllers/AddPropertyViewController/AddPropertyViewController.swift
+++ b/Example/SourcePointMetaApp/Controllers/AddPropertyViewController/AddPropertyViewController.swift
@@ -249,13 +249,13 @@ class AddPropertyViewController: BaseViewController,TargetingParamCellDelegate, 
         self.loadConsentInfoController(userConsents: userConsent)
     }
     
-    func onError(error: CCPAConsentViewControllerError?) {
-        logger.log("Error: %{public}@", [error?.description ?? "Something Went Wrong"])
+    func onError(ccpaError: CCPAConsentViewControllerError?) {
+        logger.log("Error: %{public}@", [ccpaError?.description ?? "Something Went Wrong"])
         let okHandler = {
             self.hideIndicator()
             self.dismiss(animated: false, completion: nil)
         }
-        AlertView.sharedInstance.showAlertView(title: Alert.message, message: error?.description ?? "Something Went Wrong", actions: [okHandler], titles: [Alert.ok], actionStyle: UIAlertController.Style.alert)
+        AlertView.sharedInstance.showAlertView(title: Alert.message, message: ccpaError?.description ?? "Something Went Wrong", actions: [okHandler], titles: [Alert.ok], actionStyle: UIAlertController.Style.alert)
     }
     
     

--- a/Example/SourcePointMetaApp/Controllers/ConsentViewController/ConsentDetailsViewController.swift
+++ b/Example/SourcePointMetaApp/Controllers/ConsentViewController/ConsentDetailsViewController.swift
@@ -142,13 +142,13 @@ class ConsentDetailsViewController: BaseViewController, WKNavigationDelegate, Co
         self.hideIndicator()
     }
     
-    func onError(error: CCPAConsentViewControllerError?) {
-        logger.log("Error: %{public}@", [error?.description ?? "Something Went Wrong"])
+    func onError(ccpaError: CCPAConsentViewControllerError?) {
+        logger.log("Error: %{public}@", [ccpaError?.description ?? "Something Went Wrong"])
         let okHandler = {
             self.hideIndicator()
             self.dismiss(animated: false, completion: nil)
         }
-        AlertView.sharedInstance.showAlertView(title: Alert.message, message: error?.description ?? "Something Went Wrong", actions: [okHandler], titles: [Alert.ok], actionStyle: UIAlertController.Style.alert)
+        AlertView.sharedInstance.showAlertView(title: Alert.message, message: ccpaError?.description ?? "Something Went Wrong", actions: [okHandler], titles: [Alert.ok], actionStyle: UIAlertController.Style.alert)
     }
     
     @IBAction func showPMAction(_ sender: Any) {

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ extension ViewController: ConsentDelegate {
         print("US Privacy String:", UserDefaults.standard.string(forKey: CCPAConsentViewController.IAB_PRIVACY_STRING_KEY)!)
     }
 
-    func onError(error: CCPAConsentViewControllerError?) {
-        logger.log("Error: %{public}@", [error?.description ?? "Something Went Wrong"])
+    func onError(ccpaError: CCPAConsentViewControllerError?) {
+        logger.log("Error: %{public}@", [ccpaError?.description ?? "Something Went Wrong"])
     }
 }
 ```
@@ -121,8 +121,8 @@ extension ViewController: ConsentDelegate {
     }
 }
 
-- (void)onErrorWithError:(CCPAConsentViewControllerError *)error {
-    NSLog(@"Something went wrong: %@", error);
+- (void)onErrorWithCcpaError:(CCPAConsentViewControllerError *)ccpaError {
+    NSLog(@"Something went wrong: %@", ccpaError);
 }
 @end
 ```


### PR DESCRIPTION
When we integrate both SDKS(GDPR & CCPA) into a single app then we are getting conflict for `onError` method as declaration is same in Objective-C selector. 
Now we have changed the declaration of `onError` method.