### PR TITLE
[SP-5126] Rename Error classes to CCPAError classes

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: CocoaPod Install
         run: cd Example && pod install
-      - name: testing -> iPhone 11 (iOS 13.6)
-        run: xcodebuild test -scheme ConsentViewController-Example -workspace Example/CCPAConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.6' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+      - name: testing -> iPhone 11 (iOS 13.7)
+        run: xcodebuild test -scheme ConsentViewController-Example -workspace Example/CCPAConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.7' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"

--- a/CCPAConsentViewController.podspec
+++ b/CCPAConsentViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CCPAConsentViewController'
-  s.version          = '1.3.2'
+  s.version          = '1.3.3'
   s.summary          = 'SourcePoint\'s CCPAConsentViewController to handle privacy consents.'
   s.homepage         = 'https://www.sourcepoint.com'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/CCPAConsentViewController/Classes/CCPAConsentViewControllerError.swift
+++ b/CCPAConsentViewController/Classes/CCPAConsentViewControllerError.swift
@@ -16,7 +16,7 @@ import Foundation
     }
 }
 
-@objcMembers public class GeneralRequestError: CCPAConsentViewControllerError {
+@objcMembers public class CCPAGeneralRequestError: CCPAConsentViewControllerError {
     public let url, response, error: String
 
     public var failureReason: String? { return "The request to: \(url) failed with response: \(response) and error: \(error)" }
@@ -34,7 +34,7 @@ import Foundation
     override public var description: String { return "\(failureReason!)" }
 }
 
-@objcMembers public class APIParsingError: CCPAConsentViewControllerError {
+@objcMembers public class CCPAAPIParsingError: CCPAConsentViewControllerError {
     private let parsingError: Error?
     private let endpoint: String
 
@@ -51,17 +51,17 @@ import Foundation
     public var failureReason: String? { return description }
 }
 
-@objcMembers public class UnableToLoadJSReceiver: CCPAConsentViewControllerError {
+@objcMembers public class CCPAUnableToLoadJSReceiver: CCPAConsentViewControllerError {
     public var failureReason: String? { return "Unable to load the JSReceiver.js resource." }
     override public var description: String { return "\(failureReason!)\n" }
 }
 
-@objcMembers public class NoInternetConnection: CCPAConsentViewControllerError {
+@objcMembers public class CCPANoInternetConnection: CCPAConsentViewControllerError {
     public var failureReason: String? { return "The device is not connected to the internet." }
     override public var description: String { return "\(failureReason!)\n" }
 }
 
-@objcMembers public class MessageEventParsingError: CCPAConsentViewControllerError {
+@objcMembers public class CCPAMessageEventParsingError: CCPAConsentViewControllerError {
     let message: String
 
     init(message: String) {
@@ -75,12 +75,12 @@ import Foundation
     override public var description: String { return "\(failureReason!)\n" }
 }
 
-@objcMembers public class WebViewError: CCPAConsentViewControllerError {
+@objcMembers public class CCPAWebViewError: CCPAConsentViewControllerError {
     public var failureReason: String? { return "Something went wrong in the webview" }
     override public var description: String { return "\(failureReason!)\n" }
 }
 
-@objcMembers public class URLParsingError: CCPAConsentViewControllerError {
+@objcMembers public class CCPAURLParsingError: CCPAConsentViewControllerError {
     let urlString: String
 
     init(urlString: String) {
@@ -94,7 +94,7 @@ import Foundation
     override public var description: String { return "\(failureReason!)\n" }
 }
 
-@objcMembers public class InvalidArgumentError: CCPAConsentViewControllerError {
+@objcMembers public class CCPAInvalidArgumentError: CCPAConsentViewControllerError {
     let message: String
 
     init(message: String) {

--- a/CCPAConsentViewController/Classes/MessageWebViewController.swift
+++ b/CCPAConsentViewController/Classes/MessageWebViewController.swift
@@ -22,7 +22,7 @@ class MessageWebViewController: MessageViewController, WKUIDelegate, WKNavigatio
         guard let scriptSource = try? String(
             contentsOfFile: Bundle(for: CCPAConsentViewController.self).path(forResource: MessageWebViewController.MESSAGE_HANDLER_NAME, ofType: "js")!)
             else {
-                consentDelegate?.onError?(ccpaError: UnableToLoadJSReceiver())
+                consentDelegate?.onError?(ccpaError: CCPAUnableToLoadJSReceiver())
                 return nil
         }
         let script = WKUserScript(source: scriptSource, injectionTime: .atDocumentStart, forMainFrameOnly: true)
@@ -147,7 +147,7 @@ class MessageWebViewController: MessageViewController, WKUIDelegate, WKNavigatio
         if connectvityManager.isConnectedToNetwork() {
             webview?.load(URLRequest(url: url))
         } else {
-            onError(error: NoInternetConnection())
+            onError(error: CCPANoInternetConnection())
         }
     }
 
@@ -162,7 +162,7 @@ class MessageWebViewController: MessageViewController, WKUIDelegate, WKNavigatio
 
     override func loadPrivacyManager() {
         guard let url = pmUrl() else {
-            onError(error: URLParsingError(urlString: "PMUrl"))
+            onError(error: CCPAURLParsingError(urlString: "PMUrl"))
             return
         }
         load(url: url)
@@ -207,7 +207,7 @@ class MessageWebViewController: MessageViewController, WKUIDelegate, WKNavigatio
             let body = message.body as? [String: Any?],
             let name = body["name"] as? String
         else {
-            onError(error: MessageEventParsingError(message: Optional(message.body).debugDescription))
+            onError(error: CCPAMessageEventParsingError(message: Optional(message.body).debugDescription))
             return
         }
 
@@ -222,12 +222,12 @@ class MessageWebViewController: MessageViewController, WKUIDelegate, WKNavigatio
                 let actionType = payload["type"] as? Int,
                 let action = Action(rawValue: actionType)
             else {
-                onError(error: MessageEventParsingError(message: Optional(message.body).debugDescription))
+                onError(error: CCPAMessageEventParsingError(message: Optional(message.body).debugDescription))
                 return
             }
             onAction(action, consents: getPMConsentsIfAny(payload))
         case "onError":
-            onError(error: WebViewError())
+            onError(error: CCPAWebViewError())
         default:
             print(message.body)
         }

--- a/CCPAConsentViewController/Classes/PropertyName.swift
+++ b/CCPAConsentViewController/Classes/PropertyName.swift
@@ -17,7 +17,7 @@ import Foundation
     private static func validate(_ string: String) throws -> String {
         let regex = try NSRegularExpression(pattern: validPattern, options: [])
         if regex.matches(in: string, options: [], range: NSRange(location: 0, length: string.count)).isEmpty {
-            throw InvalidArgumentError(message: "PropertyName can only include letters, numbers, '.', ':', '-' and '/'. \(string) passed is invalid")
+            throw CCPAInvalidArgumentError(message: "PropertyName can only include letters, numbers, '.', ':', '-' and '/'. \(string) passed is invalid")
         } else {
             return string
         }

--- a/CCPAConsentViewController/Classes/SourcePointClient/SimpleClient.swift
+++ b/CCPAConsentViewController/Classes/SourcePointClient/SimpleClient.swift
@@ -85,7 +85,7 @@ class SimpleClient: HttpClient {
     func request(_ urlRequest: URLRequest, _ completionHandler: @escaping CompletionHandler) {
         logRequest(urlRequest, urlRequest.httpBody)
         guard connectivityManager.isConnectedToNetwork() else {
-            completionHandler(nil, NoInternetConnection())
+            completionHandler(nil, CCPANoInternetConnection())
             return
         }
         session.configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
@@ -94,14 +94,14 @@ class SimpleClient: HttpClient {
                 self?.logResponse(urlRequest, data)
                 data != nil ?
                     completionHandler(data, nil) :
-                    completionHandler(nil, GeneralRequestError(urlRequest.url, response, error))
+                    completionHandler(nil, CCPAGeneralRequestError(urlRequest.url, response, error))
             }
         }.resume()
     }
 
     func post(url: URL?, body: Data?, completionHandler: @escaping CompletionHandler) {
         guard let _url = url else {
-            completionHandler(nil, GeneralRequestError(url, nil, nil))
+            completionHandler(nil, CCPAGeneralRequestError(url, nil, nil))
             return
         }
         var urlRequest = URLRequest(url: _url)
@@ -113,7 +113,7 @@ class SimpleClient: HttpClient {
 
     func get(url: URL?, completionHandler: @escaping CompletionHandler) {
         guard let _url = url else {
-            completionHandler(nil, GeneralRequestError(url, nil, nil))
+            completionHandler(nil, CCPAGeneralRequestError(url, nil, nil))
             return
         }
         request(URLRequest(url: _url), completionHandler)

--- a/CCPAConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/CCPAConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -87,7 +87,7 @@ class SourcePointClient {
         return components?.url
     }
 
-    func getMessage(consentUUID: ConsentUUID, authId: String?, completionHandler: @escaping (MessageResponse?, APIParsingError?) -> Void) {
+    func getMessage(consentUUID: ConsentUUID, authId: String?, completionHandler: @escaping (MessageResponse?, CCPAAPIParsingError?) -> Void) {
         let url = getMessageUrl(consentUUID, propertyName: propertyName, authId: authId)
         client.get(url: url) { [weak self] data, error in
             do {
@@ -96,10 +96,10 @@ class SourcePointClient {
                     UserDefaults.standard.setValue(messageResponse?.meta, forKey: CCPAConsentViewController.META_KEY)
                     completionHandler(messageResponse, nil)
                 } else {
-                    completionHandler(nil, APIParsingError(url?.absoluteString ?? "getMessage", error))
+                    completionHandler(nil, CCPAAPIParsingError(url?.absoluteString ?? "getMessage", error))
                 }
             } catch {
-                completionHandler(nil, APIParsingError(url?.absoluteString ?? "getMessage", error))
+                completionHandler(nil, CCPAAPIParsingError(url?.absoluteString ?? "getMessage", error))
             }
         }
     }
@@ -111,7 +111,7 @@ class SourcePointClient {
         )
     }
 
-    func postAction(action: Action, consentUUID: ConsentUUID, consents: PMConsents?, completionHandler: @escaping (ActionResponse?, APIParsingError?) -> Void) {
+    func postAction(action: Action, consentUUID: ConsentUUID, consents: PMConsents?, completionHandler: @escaping (ActionResponse?, CCPAAPIParsingError?) -> Void) {
         let url = postActionUrl(action.rawValue)
         let meta = UserDefaults.standard.string(forKey: CCPAConsentViewController.META_KEY) ?? "{}"
         let ccpaConsents = CPPAPMConsents(rejectedVendors: consents?.vendors.rejected ?? [], rejectedCategories: consents?.categories.rejected ?? [])
@@ -124,7 +124,7 @@ class SourcePointClient {
             consents: ccpaConsents,
             meta: meta
         )) else {
-            completionHandler(nil, APIParsingError(url?.absoluteString ?? "POST consent", nil))
+            completionHandler(nil, CCPAAPIParsingError(url?.absoluteString ?? "POST consent", nil))
             return
         }
 
@@ -135,10 +135,10 @@ class SourcePointClient {
                     UserDefaults.standard.setValue(actionResponse?.meta, forKey: CCPAConsentViewController.META_KEY)
                     completionHandler(actionResponse, nil)
                 } else {
-                    completionHandler(nil, APIParsingError(url?.absoluteString ?? "POST consent", error))
+                    completionHandler(nil, CCPAAPIParsingError(url?.absoluteString ?? "POST consent", error))
                 }
             } catch {
-                completionHandler(nil, APIParsingError(url?.absoluteString ?? "POST consent", error))
+                completionHandler(nil, CCPAAPIParsingError(url?.absoluteString ?? "POST consent", error))
             }
         }
     }

--- a/CCPAConsentViewController/Classes/UserConsent.swift
+++ b/CCPAConsentViewController/Classes/UserConsent.swift
@@ -108,7 +108,7 @@ public typealias SPUsPrivacyString = String
         case "rejectedSome": status = .RejectedSome
         case "rejectedAll":  status = .RejectedAll
         case "consentedAll": status = .ConsentedAll
-        default: throw MessageEventParsingError(message: "Unknown status string: \(statusString)")
+        default: throw CCPAMessageEventParsingError(message: "Unknown status string: \(statusString)")
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
+## 1.3.3 (Oct, 09, 2020)
+*  Fixed an issue that was causing clash between GeneralRequestError class in GDPR and CCPA SDKs [#50](https://github.com/SourcePointUSA/CCPA_iOS_SDK/pull/50).
 ## 1.3.2 (Sept, 29, 2020)
-* Fixed an issue that was causing clash between onError methods in GDPR and CCPA SDKs [#48](https://github.com/SourcePointUSA/CCPA_iOS_SDK/pull/48)
+* Fixed an issue that was causing clash between onError methods in GDPR and CCPA SDKs [#48](https://github.com/SourcePointUSA/CCPA_iOS_SDK/pull/48).
 ## 1.3.1 (Aug, 13, 2020)
 * Fix an issue that'd prevent the onAction delegate method from being called [#47](https://github.com/SourcePointUSA/CCPA_iOS_SDK/pull/47).
 * Implement .description to Action class [#46](https://github.com/SourcePointUSA/CCPA_iOS_SDK/pull/46).

--- a/Example/CCPAConsentViewController_ExampleTests/CCPAConsentViewControllerErrorSpec.swift
+++ b/Example/CCPAConsentViewController_ExampleTests/CCPAConsentViewControllerErrorSpec.swift
@@ -20,38 +20,38 @@ class CCPAConsentViewControllerErrorSpec: QuickSpec {
 
             it("Test GeneralRequestError method") {
                 let url = URL(string: urlString)
-                let errorObject = GeneralRequestError(url, nil, nil)
+                let errorObject = CCPAGeneralRequestError(url, nil, nil)
                 expect(errorObject.description).to(
                     equal("The request to: \(urlString) failed with response: <Unknown Response> and error: <Unknown Error>"))
             }
 
             it("Test APIParsingError method") {
-                let errorObject = APIParsingError(urlString, nil)
+                let errorObject = CCPAAPIParsingError(urlString, nil)
                 expect(errorObject.description).to(equal("Error parsing response from \(urlString): nil"))
             }
 
             it("Test NoInternetConnection method") {
-                let errorObject = NoInternetConnection()
+                let errorObject = CCPANoInternetConnection()
                 expect(errorObject.failureReason).to(equal("The device is not connected to the internet."))
             }
 
             it("Test MessageEventParsingError method") {
-                let errorObject = MessageEventParsingError(message: "The operation couldn't be completed")
+                let errorObject = CCPAMessageEventParsingError(message: "The operation couldn't be completed")
                 expect(errorObject.failureReason).to(equal("Could not parse message coming from the WebView The operation couldn't be completed"))
             }
 
             it("Test WebViewError method") {
-                let errorObject = WebViewError()
+                let errorObject = CCPAWebViewError()
                 expect(errorObject.failureReason).to(equal("Something went wrong in the webview"))
             }
 
             it("Test URLParsingError method") {
-                let errorObject = URLParsingError(urlString: urlString)
+                let errorObject = CCPAURLParsingError(urlString: urlString)
                 expect(errorObject.failureReason).to(equal("Could not parse URL: \(urlString)"))
             }
 
             it("Test InvalidArgumentError method") {
-                let errorObject = InvalidArgumentError(message: "The operation couldn't be completed")
+                let errorObject = CCPAInvalidArgumentError(message: "The operation couldn't be completed")
                 expect(errorObject.description).to(equal("The operation couldn't be completed"))
             }
         }

--- a/Example/CCPAConsentViewController_ExampleTests/SimpleClientSpec.swift
+++ b/Example/CCPAConsentViewController_ExampleTests/SimpleClientSpec.swift
@@ -138,7 +138,7 @@ class SimpleClientSpec: QuickSpec {
                 let session = URLSessionMock(
                     configuration: URLSessionConfiguration.default,
                     data: nil,
-                    error: GeneralRequestError(nil, nil, nil)
+                    error: CCPAGeneralRequestError(nil, nil, nil)
                 )
                 let client = SimpleClient(
                     connectivityManager: ConnectivityMock(connected: true),
@@ -161,7 +161,7 @@ class SimpleClientSpec: QuickSpec {
                     dispatchQueue: DispatchQueue.main
                 )
                 client.request(self.exampleRequest) { _, e in error = e! }
-                expect(error).toEventually(beAKindOf(NoInternetConnection.self))
+                expect(error).toEventually(beAKindOf(CCPANoInternetConnection.self))
             }
         }
     }

--- a/Example/CCPAConsentViewController_ExampleTests/SourcePointClientSpec.swift
+++ b/Example/CCPAConsentViewController_ExampleTests/SourcePointClientSpec.swift
@@ -31,7 +31,7 @@ public class MockHttp: HttpClient {
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1), execute: {
             self.success != nil ?
                 completionHandler(self.success!, nil) :
-                completionHandler(nil, APIParsingError(url!.absoluteString, self.error))
+                completionHandler(nil, CCPAAPIParsingError(url!.absoluteString, self.error))
         })
     }
 
@@ -47,7 +47,7 @@ public class MockHttp: HttpClient {
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1), execute: {
             self.success != nil ?
                 completionHandler(self.success!, nil) :
-                completionHandler(nil, APIParsingError(url!.absoluteString, self.error))
+                completionHandler(nil, CCPAAPIParsingError(url!.absoluteString, self.error))
         })
     }
 }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1822,6 +1822,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/CCPAConsentViewController/CCPAConsentViewController-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/CCPAConsentViewController/CCPAConsentViewController-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1884,6 +1885,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/CCPAConsentViewController/CCPAConsentViewController-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/CCPAConsentViewController/CCPAConsentViewController-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We strongly recommend the use of [CocoaPods](https://cocoapods.org) in order to 
 In your `Podfile` add the following line to your app target:
 
 ```
-pod 'CCPAConsentViewController', '1.3.2'
+pod 'CCPAConsentViewController', '1.3.3'
 ```
 ### Carthage
 We also support [Carthage](https://github.com/Carthage/Carthage). It requires a couple more steps to install so we dedicated a whole [wiki page](https://github.com/SourcePointUSA/CCPA_iOS_SDK/wiki/Carthage-SDK-integration-guide) for it.


### PR DESCRIPTION
SDK is compiled with Xcode 12.0.1 so we are good with compatibility with Xcode 12 and iOS 14.